### PR TITLE
Add added HelmetSeo to Ebook Page for pretty url previews on Social Media and SEO

### DIFF
--- a/src/scenes/Ebook/Ebook.js
+++ b/src/scenes/Ebook/Ebook.js
@@ -1,10 +1,20 @@
 import React from 'react';
 import EbookLandingBanner from "./EbookLandingBanner";
+import HelmetSeo from "../../components/HelmetSeo";
 
 function Ebook() {
 
+    const seoContent = {
+        title: 'Atila Schools and Jobs Report | The Best Canadian Universities for the Best Jobs',
+        description: 'The best Canadian Universities for getting jobs at Goldman Sachs, Google, McKinsey, Pfizer and more.',
+        image: 'https://i.imgur.com/pDvsRnZ.png',
+        slug: '/schools'
+    };
+
     return (
         <React.Fragment>
+
+            <HelmetSeo content={seoContent} />
             <EbookLandingBanner/>
         </React.Fragment>
     );

--- a/src/scenes/Ebook/EbookLandingBanner.js
+++ b/src/scenes/Ebook/EbookLandingBanner.js
@@ -1,18 +1,9 @@
 import React from "react";
-import HelmetSeo from "../../components/HelmetSeo";
 
 function EbookLandingBanner() {
-  const seoContent = {
-    title: 'Atila Schools and Jobs Report | The Best Canadian Universities for the Best Jobs',
-    description: 'The best Canadian Universities for getting jobs at Goldman Sachs, Google, McKinsey, Pfizer and more.',
-    image: 'https://i.imgur.com/pDvsRnZ.png',
-    slug: '/schools'
-  };
 
   return (
     <div className='container'>
-
-      <HelmetSeo content={seoContent} />
       <h1 className='col-sm-12 text-center'>Atila Schools and Jobs Report</h1>
 
       <div className='row'>


### PR DESCRIPTION
- Add the HelmetSEO to Ebook component so it shows a nice url preview when you share it on social media

## Examples

### Facebook
![Screen Shot 2020-04-04 at 9 28 25 AM](https://user-images.githubusercontent.com/9806858/78451981-a96d5080-7656-11ea-9eb5-4d774c2d1f75.png)


### Twitter
![Screen Shot 2020-04-04 at 9 27 26 AM](https://user-images.githubusercontent.com/9806858/78451967-9e1a2500-7656-11ea-9e57-3c87fa75dfbb.png)
