### PR TITLE
Show branch name and PR number and url in netlify deploy message in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,10 +48,10 @@ jobs:
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
                 echo 'deploying to prod';
-                ./node_modules/.bin/netlify deploy --dir=./build --prod --site $NETLIFY_SITE_ID_PROD -m "${CIRCLE_BRANCH}  ${CIRCLE_PR_NUMBER} ${CIRCLE_PULL_REQUEST} ${CIRCLE_SHA1}"
+                ./node_modules/.bin/netlify deploy --dir=./build --prod --site $NETLIFY_SITE_ID_PROD -m "${CIRCLE_BRANCH} ${CIRCLE_PR_NUMBER}  ${CIRCLE_SHA1} ${CIRCLE_PULL_REQUEST}"
             else
                 echo 'deploying to staging';
-                ./node_modules/.bin/netlify deploy --dir=./build --prod --site $NETLIFY_SITE_ID_STAGING -m "${CIRCLE_BRANCH}  ${CIRCLE_PR_NUMBER} ${CIRCLE_PULL_REQUEST} ${CIRCLE_SHA1}"
+                ./node_modules/.bin/netlify deploy --dir=./build --prod --site $NETLIFY_SITE_ID_STAGING -m "${CIRCLE_BRANCH} ${CIRCLE_PR_NUMBER}  ${CIRCLE_SHA1} ${CIRCLE_PULL_REQUEST}"
             fi
 
 workflows:


### PR DESCRIPTION
- when deploying multiple branches to netlify at the same time
- it's not clear from the netlifycommit message which one is currently running in staging
- also the commit SHA is too long so we can't see the PR url that comes after
- this PR shows the branch name , PR number and commit SHA
- I also just realized that you could use the commit SHA to find what PR and branch that SHA is associated with but it's additional steps

- using the branch or PR number directly saves you an extra step

see: 
- https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
- https://github.com/netlify/cli/blob/master/docs/commands/deploy.md