### PR TITLE
remove spaces and make lowercase username creation

### DIFF
--- a/src/components/Register.js
+++ b/src/components/Register.js
@@ -101,7 +101,7 @@ class Register extends React.Component {
 
         let value = event.target.value;
         if (event.target.name === 'username') {
-            value = value.replace(/\s/g, '').toLowerCase();
+            value = value.replace(/\s/g, '');
         }
         if (event.target.type==='checkbox'){
             value = event.target.checked


### PR DESCRIPTION
- closes #132
- The part about making username search case insensitive is an issue that must be resolved on the backend
- Potential confusion for users who enter mixed case usernames and they are confused when it is not working
- Best solution for now is to make authentication case insensitive in `atila-django`