### PR TITLE
Only show add blind applications if atila direct application

### DIFF
--- a/src/scenes/Scholarship/ScholarshipAddEdit.js
+++ b/src/scenes/Scholarship/ScholarshipAddEdit.js
@@ -55,6 +55,7 @@ let scholarshipFormConfigsPage1 = [
         placeholder:"Hide names of applicants until a winner is selected",
         type: 'checkbox',
         className: 'font-weight-bold',
+        isHidden: (scholarship) => (!scholarship.is_atila_direct_application),
     },
     {
         keyName: 'criteria_info',


### PR DESCRIPTION
Fixed bug
![image](https://user-images.githubusercontent.com/59188206/104138916-9a4dc880-5375-11eb-99a4-8598c4826efd.png)

![image](https://user-images.githubusercontent.com/59188206/104138905-902bca00-5375-11eb-9762-63c9972cd613.png)


Before (This shouldn't happen because atila direct applications is not selected)
![image](https://user-images.githubusercontent.com/59188206/104138930-ac2f6b80-5375-11eb-96ae-ba3b2ba7462c.png)
