### PR TITLE
Fix autosave bug

### DIFF
--- a/src/scenes/Scholarship/ScholarshipAddEdit.js
+++ b/src/scenes/Scholarship/ScholarshipAddEdit.js
@@ -457,14 +457,13 @@ class ScholarshipAddEdit extends React.Component{
         }
         postResponsePromise
             .then(res => {
-                this.setState({isAddScholarshipMode: false});
                 const savedScholarship = ScholarshipsAPI.cleanScholarship(res.data);
                 if (!savedScholarship.is_editable) {
                     this.disableScholarshipInputs();
                 }
-                this.setState({ scholarship: savedScholarship });
 
                 if (isAddScholarshipMode) {
+                    this.setState({ scholarship: savedScholarship });
                     const successMessage = (<p>
                         <span role="img" aria-label="happy face emoji">🙂</span>
                         Successfully saved {' '}
@@ -474,6 +473,8 @@ class ScholarshipAddEdit extends React.Component{
                     </p>);
                     toastNotify(successMessage, 'info', {position: 'bottom-right'});
                 }
+
+                this.setState({isAddScholarshipMode: false});
             })
             .catch(err=> {
                 console.log({err});


### PR DESCRIPTION
Previously when a user is writing scholarship information, the cursor would jump to the beginning of the text input because the autosave was "re-setting" the data in the text box.

Fixed by not setting state after saving a scholarship. Set State is still called the first time a scholarship is called however, because some important information is automatically set for a scholarship in the backend the first time it's saved, for example a default image.