### PR TITLE
replaced existing scholarship network image with image containing more clubs

### DIFF
--- a/src/scenes/LandingPage/HowItWorks.js
+++ b/src/scenes/LandingPage/HowItWorks.js
@@ -83,7 +83,7 @@ export const howItWorksSponsorItems = [
     {
         title: "Promote Scholarship",
         body: "Atila will help you promote your scholarship to our network of over 100 schools and student organizations.",
-        image: "https://i.imgur.com/0ZOKqSz.png",
+        image: "https://i.imgur.com/dqsLgzJ.png",
         imageCaption: "A few examples of the organizations we notify when scholarships relevant to their students are launched.",
     },
     {


### PR DESCRIPTION
Updated existing scholarship network image with new network image that contains more clubs so that we are covering more groups that would be relevant to a wider range of potential sponsors.

Closes #317 

<img width="369" alt="Screen Shot 2021-01-25 at 7 10 22 PM" src="https://user-images.githubusercontent.com/57973156/105781818-39132100-5f41-11eb-9723-64a84db61f14.png">
<img width="935" alt="Screen Shot 2021-01-25 at 7 11 08 PM" src="https://user-images.githubusercontent.com/57973156/105781819-39abb780-5f41-11eb-97fe-e35ae7f938b7.png">
