### PR TITLE
reformatted how verification error is displayed: Use the new API format of "error" instead of "message"

### DIFF
--- a/src/components/VerifyAccount.js
+++ b/src/components/VerifyAccount.js
@@ -3,6 +3,7 @@ import React from 'react';
 import {PasswordShowHide} from "./Register";
 import UserProfileAPI from "../services/UserProfileAPI";
 import ResponseDisplay from "./ResponseDisplay";
+import { getErrorMessage } from '../services/utils';
 
 class VerifyAccount extends React.Component {
 
@@ -71,8 +72,9 @@ class VerifyAccount extends React.Component {
             })
             .catch(err => {
                 console.log({err});
+                console.log("getErrorMessage(err)", getErrorMessage(err));
                 if (err.response && err.response.data) {
-                    this.setState({ responseError: err.response.data});
+                    this.setState({ responseError: getErrorMessage(err)});
                 }
             })
             .finally(res => {


### PR DESCRIPTION
Use the new API format of "error" instead of "message"

Changed in https://github.com/ademidun/atila-django/pull/240

https://github.com/ademidun/atila-django/pull/240/commits/b95a29ccbd71a0773dd9123da1383e032778437d

https://github.com/ademidun/atila-django/pull/240/commits/b95a29ccbd71a0773dd9123da1383e032778437d#diff-a8a71fdeb01c142962cd4a19819579189dc0e2205ee6fbc05ee58d5f10e0fafeR722