### PR TITLE
added laurentian, langara, Dalhousie, Ryerson, and Georgetown DSB to social proof

### DIFF
--- a/src/scenes/LandingPage/SocialProof.js
+++ b/src/scenes/LandingPage/SocialProof.js
@@ -4,74 +4,104 @@ const schoolImages = [
     {
         "url": "https://imgur.com/VXhmyOx.jpg",
         "alt": "University of Toronto",
+        "width":"120",
+        "height":"90",
     },
     {
         "url": "https://imgur.com/6kJAH06.jpg",
         "alt": "Ivey Business School",
+        "width":"120",
+        "height":"75",
     },
     {
         "url": "https://i.imgur.com/BSIjvEC.jpg",
         "alt": "McGill University",
+        "width":"140",
+        "height":"60",
     },
     {
         "url": "https://i.imgur.com/zOQZsdL.jpg",
         "alt": "University of British Columbia",
+        "width":"150",
+        "height":"75",
     },
     {
         "url": "https://i.imgur.com/XPjzuEl.jpg",
         "alt": "University of Alberta",
+        "width":"155",
+        "height":"50",
     },
     {
         "url": "https://i.imgur.com/eHdi4cu.jpg",
         "alt": "Simon Fraser University",
+        "width":"175",
+        "height":"80",
     },
     {
         "url": "https://i.imgur.com/aPk1hmk.jpg",
         "alt": "Humber College",
+        "width":"110",
+        "height":"65",
     },
     {
         "url": "https://i.imgur.com/YLUk42o.jpg",
         "alt": "Carleton University",
+        "width":"120",
+        "height":"70",
     },
     {
         "url": "https://i.imgur.com/erf5H8M.jpg",
         "alt": "Ryerson University",
+        "width":"120",
+        "height":"75",
     },
     {
         "url": "https://i.imgur.com/IWerHJh.jpg",
         "alt": "Dalhousie University",
+        "width":"140",
+        "height":"50",
     },
     {
         "url": "https://i.imgur.com/w2ztHKJ.png",
         "alt": "Langara College",
+        "width":"140",
+        "height":"150",
     },
     {
         "url": "https://i.imgur.com/Z4IkK8h.png",
         "alt": "Laurentian University",
+        "width":"210",
+        "height":"50",
     },
     {
         "url": "https://i.imgur.com/oJu53qu.jpg",
         "alt": "Toronto District School Board",
+        "width":"130",
+        "height":"100",
     },
     {
         "url": "https://i.imgur.com/MCacdYu.jpg",
         "alt": "Waterloo Region District School Board",
+        "width":"180",
+        "height":"85",
     },
     {
         "url": "https://i.imgur.com/CBbAmV0.jpg",
         "alt": "Durham District School Board",
+        "width":"90",
+        "height":"100",
     },
     {
         "url": "https://i.imgur.com/bwUy1WL.jpg",
         "alt": "Waterloo Catholic District School Board",
+        "width":"170",
+        "height":"105",
     },
     {
         "url": "https://i.imgur.com/XghA3ft.jpg",
         "alt": "Halton District School Board",
-    },
-    {
-        "url": "https://i.imgur.com/15trTBH.jpg",
-        "alt": "Georgetown District School Board",
+        "width":"100",
+        "height":"85",
     },
 
 ]
@@ -86,7 +116,7 @@ export function SocialProof() {
                 </h3>
                 <div>
                     {schoolImages.map (schoolImage => (
-                    <img src={schoolImage.url} width="150" height="auto" alt={schoolImage.alt}/>
+                    <img src={schoolImage.url} width={schoolImage.width} height={schoolImage.height} alt={schoolImage.alt}/>
                     ))}
                 </div>
             </div>


### PR DESCRIPTION
Added laurentian, langara, Dalhousie, Ryerson, and Georgetown DSB to social proof. Also changed code to an array with all schools. 

I agree that the code is easier to read and manage, but the appearance is worse in my opinion than if it was customized to every image. 
<img width="985" alt="Screen Shot 2021-02-14 at 12 45 40 AM" src="https://user-images.githubusercontent.com/67034726/107872263-fd8fb680-6e5d-11eb-84dd-c9d7e0a7ee7b.png">

Also, for some reason I can't see the direct application on my landing page in my local host, but I can see it when I get on staging.
<img width="985" alt="Screen Shot 2021-02-14 at 12 45 40 AM" src="https://user-images.githubusercontent.com/67034726/107872320-59f2d600-6e5e-11eb-9a64-d90d5b6922f1.png">

Here's what I see on staging:
<img width="1440" alt="Screen Shot 2021-02-14 at 12 49 04 AM" src="https://user-images.githubusercontent.com/67034726/107872333-7db61c00-6e5e-11eb-8099-e7ae2a564d44.png">
