### PR TITLE
Updated the Blind Applications Message

### DIFF
--- a/src/models/Scholarship.js
+++ b/src/models/Scholarship.js
@@ -259,8 +259,7 @@ export const BlindApplicationsExplanationMessage = () => (
             type="info"
             message={<div style={{whiteSpace: "pre-line"}}>
                 This is a Blind Application Scholarship: The names of the applicants
-                are hidden to the scholarship reviewer
-                until a winner has been selected. <br/> This is done to reduce bias in the application review process.
+                are hidden until all submitted applications have been scored. <br/> This is done to reduce bias in the application review process.
                 <br /> <Link to="/blog/tomiwa/atila-blind-applications">Learn More</Link>
             </div>}
         />


### PR DESCRIPTION
changed the from "the names of the applicants are hidden to the scholarship reviewer until a winner has been selected" to "the names of the applicants are hidden until all submitted applications have been scored."
![blindmobile](https://user-images.githubusercontent.com/64740620/108101954-f3380d00-7055-11eb-8594-865d93458ea0.jpg)
![blinddesktop](https://user-images.githubusercontent.com/64740620/108101958-f3d0a380-7055-11eb-9e90-a1386ac34302.jpg)
