### PR TITLE
added unsplash attribution and changed heading sizes in Terms and Conditions to resemble how to start/get scholarships

### DIFF
--- a/src/components/TermsConditions.js
+++ b/src/components/TermsConditions.js
@@ -92,15 +92,12 @@ function TermsConditions() {
                     contact us via any of the ways described in the Footer of our home page.</p>
 
                 <p>Thank you for choosing Atila!</p>
-            </div>
-            <div className="container m-3">
-                <div className="card p-3">
-                    <h1>Credits</h1>
-                    <h3>Images</h3>
-                    <p><a href="https://unsplash.com/photos/uhnbTZC7N9k">Photo</a> by <a href="https://unsplash.com/@zoegayah">Zoë Gayah Jonker</a> on Unsplash</p>
-                    <p><a href="https://unsplash.com/photos/G8cB8hY3yvU">Photo</a> by <a href="https://unsplash.com/@ralu_gal"> Ralu Gal</a> on Unsplash</p>
-                    <p><a href="https://unsplash.com/photos/2s6ORaJY6gI">Photo</a> by <a href="https://unsplash.com/@celine_sayuri/likes">Celine Sayuri Tagami</a> on Unsplash</p>
-                </div>
+                <hr></hr>
+                <h1>Credits</h1>
+                <h3>Images</h3>
+                <p><a href="https://unsplash.com/photos/uhnbTZC7N9k">Photo</a> by <a href="https://unsplash.com/@zoegayah">Zoë Gayah Jonker</a> on Unsplash</p>
+                <p><a href="https://unsplash.com/photos/G8cB8hY3yvU">Photo</a> by <a href="https://unsplash.com/@ralu_gal"> Ralu Gal</a> on Unsplash</p>
+                <p><a href="https://unsplash.com/photos/2s6ORaJY6gI">Photo</a> by <a href="https://unsplash.com/@celine_sayuri/likes">Celine Sayuri Tagami</a> on Unsplash</p>
             </div>
         </div>
     );


### PR DESCRIPTION
Added unsplash attributions for the three images we used:
closes #380 

<img width="1422" alt="Screen Shot 2021-04-07 at 4 10 49 PM" src="https://user-images.githubusercontent.com/67034726/113928026-3abc5900-97bc-11eb-8f5b-79c4e63061ed.png">

The view on phone:
<img width="279" alt="Screen Shot 2021-04-07 at 4 09 43 PM" src="https://user-images.githubusercontent.com/67034726/113928046-40b23a00-97bc-11eb-8bcb-cfae848814d5.png">

Also changed Headers to resemble the theme in [How to Apply for Scholarships](https://atila.ca/apply) and [How to Start a scholarship](https://atila.ca/start)
<img width="1427" alt="Screen Shot 2021-04-07 at 4 10 27 PM" src="https://user-images.githubusercontent.com/67034726/113928181-6dfee800-97bc-11eb-8591-3f3fb190a427.png">

View on iphone:
<img width="282" alt="Screen Shot 2021-04-07 at 4 10 09 PM" src="https://user-images.githubusercontent.com/67034726/113928216-79eaaa00-97bc-11eb-944a-9fcb3ab229ee.png">
<img width="276" alt="Screen Shot 2021-04-07 at 4 09 58 PM" src="https://user-images.githubusercontent.com/67034726/113928231-7ce59a80-97bc-11eb-9a6d-b2ea0c67e099.png">

I also wanted to add padding and indentation for "<"p">" tags, but I remembered that you didn't want me to add it as a css file? Adding inline style would be too tedious imo. 
