### PR TITLE
show scholarship action buttons for admin users

### DIFF
--- a/src/scenes/Scholarship/ScholarshipManage.js
+++ b/src/scenes/Scholarship/ScholarshipManage.js
@@ -517,7 +517,7 @@ class ScholarshipManage extends React.Component {
                     Un-Submitted applications (under draft): {unsubmittedApplications.length}
                 </h2>
 
-                {isScholarshipOwner || userProfile.is_atila_admin &&
+                {(isScholarshipOwner || userProfile.is_atila_admin) &&
                 <>
 
                     <br />


### PR DESCRIPTION
- In the scholarship applications management page, Currently only the scholarship owner can see the actions such as: email applicants, invite collaborator etc.
- This PR allows all admin users to see those action buttons
- A future PR will use a more fine grained access control policy to determine who can perform what actions

## Before

![Screen Shot 2021-04-29 at 11 13 44 PM](https://user-images.githubusercontent.com/9806858/116644200-bd11e600-a940-11eb-8d58-f74cb4f02303.png)


## After

![Screen Shot 2021-04-30 at 12 09 42 AM](https://user-images.githubusercontent.com/9806858/116647392-6dcfb380-a948-11eb-93d9-43adff827dd1.png)
