### PR TITLE
hyperlinked to finalists page from landing page

### DIFF
--- a/src/scenes/LandingPage/HowItWorks.js
+++ b/src/scenes/LandingPage/HowItWorks.js
@@ -121,7 +121,8 @@ export function HowItWorksStudent() {
             <h2 className="col-sm-12 text-center">
                 <Link to="/register">Create Profile.</Link>{' '}
                 <Link to="/scholarship">Apply for Scholarships.</Link>{' '}
-                Get Funded.
+                <Link to="/finalists">Get Funded.</Link>{' '}
+            
             </h2>
             <h5 className="col-sm-12 text-center text-muted">Atila is 100% free for students</h5>
             <SocialProof />


### PR DESCRIPTION
closes #398, hyperlinked "get funded" on landing page to finalists page
![image](https://user-images.githubusercontent.com/83561566/118576479-d6d76980-b745-11eb-938e-36b017275c1d.png)

