### PR TITLE
fixed countWords function to account when string is null

### DIFF
--- a/src/services/TextUtils.js
+++ b/src/services/TextUtils.js
@@ -3,7 +3,7 @@ class TextUtils {
     static countWords = (str) => {
         // https://stackoverflow.com/a/18679592/5405197
         //  TODO: The function below doesn't count words on new line as a new word
-        if(str == null) {
+        if(!str) {
             return 0;
         }
         return str.trim().split(/\s+/).length;


### PR DESCRIPTION
[Loom video explanation](https://www.loom.com/share/fc5012ebe3414248be9419ca2ee66421) describing the issue, how I diagnosed the problem, and how I applied a change

Error occurred when viewing application form; 
![screen_shot_2021-08-05_at_1 17 16_pm](https://user-images.githubusercontent.com/67034726/128405025-f0c12783-ad29-4d89-94b4-fa154daeb7d4.png)

Whenever the error is along the lines of "cannot read properties of undefined", it usually means that the function does not handle null or undefined inputs.

Viewing application form now accounts for this, and there's no errors when entering the page:
<img width="1413" alt="Screen Shot 2021-08-05 at 11 52 48 AM" src="https://user-images.githubusercontent.com/67034726/128405286-0db99d0d-7d78-4943-8390-2dcaa574cdd5.png">
