### PR TITLE
use mock data when visiting website from a unique deploy url

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -122,13 +122,7 @@ const { requestSanitizer, responseSanitizer } = LogrocketFuzzySanitizer.setup(pr
 class App extends React.Component {
   constructor(props) {
     super(props);
-    /**
-     * The logic to only allow mocks in dev is alreay handled inside the function initializeMocks()
-     * Having it here is redundant but it makes it clearer to the user that we only call the mock in dev environments.
-     */
-    if (Environment.name === "dev") {
-      MockAPI.initializeMocks();
-    }
+    MockAPI.initializeMocks();
     if (process.env.NODE_ENV !== "test" &&
         !navigator.userAgent.includes('https://github.com/prerender/prerender')) {
       // TODO: mock LogRocket.init and setupLogRocketReact and all uses of LogRocket in Navbar.js and Register.js

--- a/src/services/mocks/MockAPI.js
+++ b/src/services/mocks/MockAPI.js
@@ -16,13 +16,26 @@ export class MockAPI {
 
     static initializeMocks = () => {
 
-        if (localStorage.getItem('ATILA_MOCK_API_CALLS') !== "true" || Environment.name !== "dev") {
+        if (Environment.name === "prod") {
             if (localStorage.getItem('MOCK_API_CALLS') === "true") {
                 console.log(`"User tried to use MOCK_API_CALLS local storage setting in" ${Environment.name} environment.
                 This feature is only available in 'dev'`)
             }
             return
         }
+
+        if (Environment.name === "staging") {
+            if (!window.location.host.includes("--atila-staging.netlify.app")) {
+                return
+            } else {
+                console.log("Using mock data due to unique deploy url: '--atila-staging.netlify.app'")
+            }
+        }
+
+        if (Environment.name === "dev" && localStorage.getItem('MOCK_API_CALLS') !== "true") {
+            return
+        }
+
         var mock = new MockAdapter(axios);
         
         mock.onAny(ContactsAPI.contactsApiQueryUrl).reply(200, ContactsQuery1);


### PR DESCRIPTION
closes #454

- compare https://611d3b6fc6c9ef0eb0427143--atila-staging.netlify.app/scholarship
- old way: https://61176b8b52615b6030d86e4c--atila-staging.netlify.app/scholarship


## New Way

![Screen Shot 2021-08-18 at 7 51 37 PM](https://user-images.githubusercontent.com/9806858/129986583-dfb60cf6-e1cd-4d66-8943-4d7daad6bd40.png)


## Old Way

![Screen Shot 2021-08-18 at 7 53 27 PM](https://user-images.githubusercontent.com/9806858/129986593-ccc1a5d9-1eef-4e8e-88aa-000d1d83dc4a.png)
