### PR TITLE
change bcc_chance from parseInt to parseFloat

### DIFF
--- a/src/services/MessagingCampaignAPI.js
+++ b/src/services/MessagingCampaignAPI.js
@@ -24,7 +24,7 @@ class MessagingCampaignAPI {
          * @type {AxiosPromise}
          */
         data.limit = Number.parseInt(data.limit);
-        data.bcc_chance = Number.parseInt(data.bcc_chance);
+        data.bcc_chance = Number.parseFloat(data.bcc_chance);
 
         const apiCompletionPromise = request({
             method: 'post',


### PR DESCRIPTION
otherwise, values less than 1 will be coerced to 0 which somehow results in bcc_chance being null and causing an error.

closes https://github.com/ademidun/atila-django/issues/361