### PR TITLE
commented out the autocomplete form

### DIFF
--- a/src/components/Query/QueryItem.js
+++ b/src/components/Query/QueryItem.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import {withRouter} from "react-router-dom";
 import {connect} from "react-redux";
 import {  MASTER_LIST_WITH_CATEGORY_LABEL, MASTER_LIST_WITH_CATEGORY_LABEL_ADMIN, MASTER_LIST_WITH_CATEGORY_LABEL_USER_PROFILE } from '../../models/ConstantsForm';
-import AutoComplete from '../AutoComplete';
+// import AutoComplete from '../AutoComplete';
 import { Tag, Radio, Input, Button } from 'antd';
 import { prettifyKeys } from '../../services/utils';
 
@@ -165,14 +165,17 @@ export class QueryItem extends React.Component {
                 }
 
                 {queryInputType === queryBuilder &&
-                    <AutoComplete   suggestions={suggestions}
-                    placeholder={placeHolder||"Search by school, program, ethnicity, activity, industry, or more"}
-                    value={searchQuery}
-                    getSuggestionValue={suggestion => suggestion.value}
-                    renderSuggestion={this.renderSuggestion}
-                    onSuggestionSelected={this.onSuggestionSelected}
-                    inputToSuggestion={this.inputToSuggestion}
-                    keyName={'searchString'}/>
+                <>
+                {/* <AutoComplete   suggestions={suggestions}
+                placeholder={placeHolder||"Search by school, program, ethnicity, activity, industry, or more"}
+                value={searchQuery}
+                getSuggestionValue={suggestion => suggestion.value}
+                renderSuggestion={this.renderSuggestion}
+                onSuggestionSelected={this.onSuggestionSelected}
+                inputToSuggestion={this.inputToSuggestion}
+                keyName={'searchString'}/> */}
+
+                </>
                 }
                 
 


### PR DESCRIPTION
The `AutoComplete` form is crashing when used with components that aren't wrapped in `InstantSearch`.


The fix is that the wrapping of `InstantSearch` should be handled by `AutoComplete` logic.

`Uncaught TypeError: this.props.contextValue.store.getState is not a function.` See: https://github.com/algolia/react-instantsearch/issues/2897


Error likely introduced in this commit: https://github.com/ademidun/atila-client-web-app/commit/5a13f711f8bae4c7ca85b87319b211b877206bcc in PR https://github.com/ademidun/atila-client-web-app/pull/528


This one crashes on [atila.ca/clubs](https://atila.ca/clubs): https://github.com/ademidun/atila-client-web-app/blob/dcebcb4ff5b73ee8a587353bea74022ea446a8d3/src/components/Query/QueryItem.js#L167-L168

This one works: https://github.com/ademidun/atila-client-web-app/blob/658040b16ca02d97a99b89d28976e5a828febb11/src/scenes/LandingPage/Banner.jsx#L96-L97





